### PR TITLE
Fix wrong file name (wasn't matching with huggingface)

### DIFF
--- a/static/config.json
+++ b/static/config.json
@@ -38,7 +38,7 @@
         "default_history_file": "history_template.json",
         "images": "images/",
         "yuna_model_dir": "lib/models/yuna/",
-        "yuna_default_model": "yuna-ai-q5.gguf",
+        "yuna_default_model": "yuna-ggml-q5.gguf",
         "agi_model_dir": "lib/models/agi/",
         "art_default_model": "any_loli.safetensors",
         "prompts": "static/db/prompts/",


### PR DESCRIPTION
Originally from #57

**Describe the bug**
When installing and downloading yuna models from index.py or index.sh, the downloaded model is named differently from the one default in config file.

**To Reproduce**
Steps to reproduce the behavior:
1. Run `index.sh` or `index.py`
2. Download the yuna model by selecting One Click, Go Back, and Yuna.
3. Wait for it to finish downloading
4. Attempt to run it using `index.sh` or `index.py`
5. Error

**Expected behavior**
The system should work normally after download.

**Desktop (please complete the following information):**
 - OS: Ubuntu 23,10
 - Version: 26e3346

**Solution**
Change config file `"yuna_default_model": "yuna-ai-q5.gguf"` to `"yuna_default_model": "yuna-ggml-q5.gguf"`